### PR TITLE
Removed option "z" from tar since you have already updated the vds2cp…

### DIFF
--- a/vds2cp_restore.sh
+++ b/vds2cp_restore.sh
@@ -91,7 +91,7 @@ else
     sleep 5
   done &
   bgid=$!
-  tar -zxf /root/vds2cp_restore_"$vdsUSER".tar -C /root/"$vdsUSER"_restore/
+  tar -xf /root/vds2cp_restore_"$vdsUSER".tar -C /root/"$vdsUSER"_restore/
   kill "$bgid"; echo
 fi
 


### PR DESCRIPTION
….sh script take backup in .tar formt.

The restoration process is failing with the below error message
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now